### PR TITLE
fix: Allow bot owner to use commands from the bot's number

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -240,7 +240,7 @@ const isOwner = isROwner || m.fromMe
 const isMods = isROwner || global.mods.map(v => v.replace(/[^0-9]/g, '') + detectwhat).includes(m.sender)
 const isPrems = isROwner || global.prems.map(v => v.replace(/[^0-9]/g, '') + detectwhat).includes(m.sender) || _user.premium == true
 
-if (m.isBaileys) return
+if (m.isBaileys && !isOwner) return
 if (opts['nyimak'])  return
 if (!isROwner && opts['self']) return
 if (opts['swonly'] && m.chat !== 'status@broadcast')  return


### PR DESCRIPTION
This commit fixes an issue where the bot would ignore commands sent from the same number it is running on, even if they were sent by the owner.

The problem was caused by the `if (m.isBaileys) return` check in `handler.js`. This check is intended to prevent the bot from replying to its own automated messages, but it was also catching manual commands sent by the owner from the bot's account.

The fix modifies this check to `if (m.isBaileys && !isOwner) return`. This makes an exception for the owner, allowing their commands to be processed while still preventing the bot from responding to its own non-owner automated messages.