### PR TITLE
fix: Refactor private mode plugin to detect prefix-less commands

### DIFF
--- a/plugins/privatemode.js
+++ b/plugins/privatemode.js
@@ -1,75 +1,96 @@
-// Comando +priv
-let handlerPriv = async (m, { conn }) => {
-    let settings = global.db.data.settings[conn.user.jid]
-    if (!settings) settings = global.db.data.settings[conn.user.jid] = {}
-    if (!settings.authorized_users) settings.authorized_users = []
-
-    if (settings.authorized_users.includes(m.sender)) {
-        return m.reply('Ya estás autorizado para usar este bot.')
+// Handler for prefix-less commands (+priv, -priv, +grupo, -grupo)
+const handler = async (m, { conn, isAdmin }) => {
+    // Do not execute if message is not a command-like text
+    if (!m.text || !m.text.startsWith('+') && !m.text.startsWith('-')) {
+        return;
     }
-    settings.authorized_users.push(m.sender)
-    m.reply('✅ ¡Ahora estás autorizado para usar este bot!')
-}
-handlerPriv.command = ['+priv']
-handlerPriv.private = true
 
-// Comando -priv
-let handlerUnpriv = async (m, { conn }) => {
-    let settings = global.db.data.settings[conn.user.jid]
-    if (!settings || !settings.authorized_users || !settings.authorized_users.includes(m.sender)) {
-        return m.reply('No estás en la lista de usuarios autorizados.')
+    const command = m.text.toLowerCase().trim();
+    let settings = global.db.data.settings[conn.user.jid];
+    if (!settings) settings = global.db.data.settings[conn.user.jid] = {};
+
+    switch (command) {
+        case '+priv':
+            if (m.isGroup) {
+                return m.reply('Este comando solo se puede usar en chats privados.');
+            }
+            if (!settings.authorized_users) {
+                settings.authorized_users = [];
+            }
+            if (settings.authorized_users.includes(m.sender)) {
+                return m.reply('Ya estás autorizado para usar este bot.');
+            }
+            settings.authorized_users.push(m.sender);
+            m.reply('✅ ¡Ahora estás autorizado para usar este bot!');
+            break;
+
+        case '-priv':
+            if (m.isGroup) {
+                return m.reply('Este comando solo se puede usar en chats privados.');
+            }
+            if (!settings.authorized_users || !settings.authorized_users.includes(m.sender)) {
+                return m.reply('No estás en la lista de usuarios autorizados.');
+            }
+            settings.authorized_users = settings.authorized_users.filter(user => user !== m.sender);
+            m.reply('❌ Ya no estás autorizado para usar este bot.');
+            break;
+
+        case '+grupo':
+            if (!m.isGroup) {
+                return m.reply('Este comando solo se puede usar en grupos.');
+            }
+            if (!isAdmin) {
+                return m.reply('Este comando solo puede ser usado por administradores del grupo.');
+            }
+            let chat = global.db.data.chats[m.chat];
+            if (!chat) chat = global.db.data.chats[m.chat] = {};
+            chat.group_enabled = true;
+            m.reply('✅ El bot ha sido activado en este grupo.');
+            break;
+
+        case '-grupo':
+            if (!m.isGroup) {
+                return m.reply('Este comando solo se puede usar en grupos.');
+            }
+            if (!isAdmin) {
+                return m.reply('Este comando solo puede ser usado por administradores del grupo.');
+            }
+            let chat2 = global.db.data.chats[m.chat];
+            if (!chat2) chat2 = global.db.data.chats[m.chat] = {};
+            chat2.group_enabled = false;
+            m.reply('❌ El bot ha sido desactivado en este grupo.');
+            break;
     }
-    settings.authorized_users = settings.authorized_users.filter(user => user !== m.sender)
-    m.reply('❌ Ya no estás autorizado para usar este bot.')
-}
-handlerUnpriv.command = ['-priv']
-handlerUnpriv.private = true
+};
 
-// Comando +grupo
-let handlerGrupo = async (m, { conn }) => {
-    let chat = global.db.data.chats[m.chat]
-    if (!chat) chat = global.db.data.chats[m.chat] = {}
-    chat.group_enabled = true
-    m.reply('✅ El bot ha sido activado en este grupo.')
-}
-handlerGrupo.command = ['+grupo']
-handlerGrupo.group = true
-handlerGrupo.admin = true
+// This property makes the handler run for every message
+handler.all = true;
 
-// Comando -grupo
-let handlerUngrupo = async (m, { conn }) => {
-    let chat = global.db.data.chats[m.chat]
-    if (!chat) chat = global.db.data.chats[m.chat] = {}
-    chat.group_enabled = false
-    m.reply('❌ El bot ha sido desactivado en este grupo.')
-}
-handlerUngrupo.command = ['-grupo']
-handlerUngrupo.group = true
-handlerUngrupo.admin = true
+// Handler for the standard 'privatemode' command (requires prefix)
+const privatemodeHandler = async (m, { conn, text, usedPrefix, isOwner }) => {
+    if (!isOwner) {
+        return m.reply('Este comando solo puede ser usado por el propietario del bot.');
+    }
 
-// Comando privatemode
-let handlerPrivateMode = async (m, { conn, text, usedPrefix }) => {
-    let settings = global.db.data.settings[conn.user.jid]
-    if (!settings) settings = global.db.data.settings[conn.user.jid] = {}
+    let settings = global.db.data.settings[conn.user.jid];
+    if (!settings) settings = global.db.data.settings[conn.user.jid] = {};
 
-    let arg = text.toLowerCase().trim()
+    let arg = text.toLowerCase().trim();
     if (arg === 'on') {
-        settings.private_mode = true
-        m.reply('✅ El modo privado ha sido activado.')
+        settings.private_mode = true;
+        m.reply('✅ El modo privado ha sido activado.');
     } else if (arg === 'off') {
-        settings.private_mode = false
-        m.reply('❌ El modo privado ha sido desactivado. El bot ahora responderá en todos los chats.')
+        settings.private_mode = false;
+        m.reply('❌ El modo privado ha sido desactivado. El bot ahora responderá en todos los chats.');
     } else {
-        m.reply(`Uso incorrecto. Ejemplo: ${usedPrefix}privatemode on|off`)
+        m.reply(`Uso incorrecto. Ejemplo: ${usedPrefix}privatemode on|off`);
     }
-}
-handlerPrivateMode.command = ['privatemode']
-handlerPrivateMode.owner = true
+};
+
+privatemodeHandler.command = ['privatemode'];
+privatemodeHandler.owner = true;
 
 export {
-    handlerPriv as priv,
-    handlerUnpriv as unpriv,
-    handlerGrupo as grupo,
-    handlerUngrupo as ungrupo,
-    handlerPrivateMode as privatemode
-}
+    handler,
+    privatemodeHandler
+};


### PR DESCRIPTION
This commit fixes a bug where the `+priv`, `-priv`, `+grupo`, and `-grupo` commands were not being detected by the bot.

The issue was caused by the bot's command handler, which requires a standard prefix (e.g., '.', '#') to trigger a command. The `+` and `-` characters were not configured as prefixes, and the command parsing logic was not suitable for them.

This commit refactors `plugins/privatemode.js` to solve this:
- The logic for the four prefix-less commands has been moved into a `handler.all` function. This function runs on every message and checks for these specific commands directly, bypassing the prefix system.
- The `privatemode` command is kept as a separate, standard command handler that still requires a prefix, which is consistent with other owner commands.